### PR TITLE
docs: @hzoo suggested using babel-register rather babel-core/register

### DIFF
--- a/content/docs/tutorials/es2015.md
+++ b/content/docs/tutorials/es2015.md
@@ -26,12 +26,12 @@ By relying on the preset, there are only a few dependencies that we need to add
 test coverage to our ES2015 project:
 
 ```bash
-npm i babel-cli babel-core babel-plugin-istanbul babel-preset-es2015 cross-env mocha chai nyc --save-dev
+npm i babel-cli babel-register babel-plugin-istanbul babel-preset-es2015 cross-env mocha chai nyc --save-dev
 ```
 
 * `babel-cli`: is the command-line interface for babel; we use it during the build step.
-* `babel-core`/`babel-preset-es2015`: these two libraries are all that's required to
-  compile your ES2015 code.
+* `babel-register`: automatically compiles ES2015 JavaScript as it's required in your
+   tests.
 * `babel-plugin-istanbul`: this plugin adds coverage instrumentation to your ES2015 code
    as it's compiled.
 * `nyc`: outputs the coverage information to disk, and handles running reports.
@@ -42,7 +42,7 @@ npm i babel-cli babel-core babel-plugin-istanbul babel-preset-es2015 cross-env m
 
 **.babelrc**
 
-We place a `.babelrc` in the root of our project which is used by `babel-core`
+We place a `.babelrc` in the root of our project which is used by `babel-cli`
 to apply the compilation process:
 
 ```json
@@ -69,15 +69,15 @@ plugin only when `NODE_ENV=test`.
 ```json
 {"nyc": {
   "require": [
-    "babel-core/register"
+    "babel-register"
   ],
   "sourceMap": false,
   "instrument": false
 }}
 ```
 
-* `nyc.require.babel-core/register`: indicates that we should automatically run
-  `require('babel-core/register')` as `nyc` loads our tests. This allows us to
+* `nyc.require.babel-register`: indicates that we should automatically run
+  `require('babel-register')` as `nyc` loads our tests. This allows us to
    write ES2015 code in our tests without running a build step (code is automatically
    compiled by babel as it is loaded).
 * `nyc.sourceMap=false`/`nyc.instrument=false`: indicates that we should not use
@@ -106,7 +106,7 @@ plugin only when `NODE_ENV=test`.
 
 ### Writing Tests
 
-Because `nyc` automatically loads `babel-core/register` there is no
+Because `nyc` automatically loads `babel-register` there is no
 build step necessary for your tests. Just write your tests using
 ES2015 syntax and `require()` the pre-compiled ES2015 JavaScript files:
 


### PR DESCRIPTION
@hzoo suggests using `babel-register` rather than `babel-core/register`; this certainly makes install sizes quite a bit smaller!