### PR TITLE
tutorials/es2015: Don't use arrow functions in describe() and it()

### DIFF
--- a/content/docs/tutorials/es2015.md
+++ b/content/docs/tutorials/es2015.md
@@ -127,8 +127,8 @@ import CoverageBabel from './index'
 
 require('chai').should()
 
-describe('CoverageBabel', function() {
-  it('returns hello world message', function() {
+describe('CoverageBabel', function () {
+  it('returns hello world message', function () {
     const cls = new CoverageBabel('Ben')
     cls.helloMessage().should.equal('hello Ben')
   })

--- a/content/docs/tutorials/es2015.md
+++ b/content/docs/tutorials/es2015.md
@@ -127,8 +127,8 @@ import CoverageBabel from './index'
 
 require('chai').should()
 
-describe('CoverageBabel', () => {
-  it('returns hello world message', () => {
+describe('CoverageBabel', function() {
+  it('returns hello world message', function() {
     const cls = new CoverageBabel('Ben')
     cls.helloMessage().should.equal('hello Ben')
   })


### PR DESCRIPTION
> Passing arrow functions (“lambdas”) to Mocha is discouraged. Due to the lexical binding of this, such functions are unable to access the Mocha context.

see https://mochajs.org/#arrow-functions