### PR TITLE
fix: update typescript and mocha setup (#504)

### DIFF
--- a/content/docs/tutorials/typescript.md
+++ b/content/docs/tutorials/typescript.md
@@ -24,9 +24,10 @@ Thanks to [@mohsen1's](http://github.com/mohsen1) [post](http://azimi.me/2016/09
     "exclude": [
       "**/*.d.ts"
     ],
-    "require": [
-      "ts-node/register"
-    ]
+    "reporter": [
+      "html"
+    ],
+    "all": true  
   }
 }
 ```
@@ -34,7 +35,7 @@ Thanks to [@mohsen1's](http://github.com/mohsen1) [post](http://azimi.me/2016/09
 ## `test/mocha.opts`
 
 ```
---compilers ts-node/register
+--require ts-node/register
 --require source-map-support/register
 --recursive
 <glob for your test files>


### PR DESCRIPTION
This fix will allow to display all included files in a report without throw an error from `ts-node`. Fix https://github.com/istanbuljs/nyc/issues/504