### PR TITLE
Add page about reports from __coverage__ object

### DIFF
--- a/content/docs/advanced/coverage-object-report.md
+++ b/content/docs/advanced/coverage-object-report.md
@@ -1,0 +1,11 @@
+---
+title: Generate report from __coverage__ object
+layout: WithQuickStart
+QuickStart:
+  title: Generate report from __coverage__ object
+---
+
+Output the contents of `window.__coverage__` (assuming it's in Istanbul 1.0 format) to `.nyc_output/out.json`. To generate HTML report for example, run:
+```bash
+nyc report --reporter=html
+```

--- a/content/docs/advanced/index.md
+++ b/content/docs/advanced/index.md
@@ -4,3 +4,4 @@ title: Advanced `nyc` Features
 
 - [Instrumenting source files](./instrument/)
 - [Process tree information](./process-tree/)
+- [Generating report from `__coverage__` object](./coverage-object-report/)


### PR DESCRIPTION
Add @bcoe's advice from https://github.com/istanbuljs/nyc/issues/641 to a new page under "Advanced Features" menu.