### PR TITLE
feat: add integrations page

### DIFF
--- a/content/integrations/index.md
+++ b/content/integrations/index.md
@@ -1,5 +1,5 @@
 ---
-title: Tools That Integrate With Istanbul
+title: Tools That Integrate With Istanbul API's
 ---
 
 The following tools integrate with Istanbul to provide JavaScript
@@ -9,9 +9,8 @@ test coverage:
   with V8's built in coverage enabled. Uses Istanbul reports for displaying
   coverage.
 * [Jest](https://github.com/facebook/jest): JavaScript testing solution that
-  works out of the box for any React project. Uses Istanbul's API for providing
-  coverage reports.
+  works out of the box for any JavaScript project. Uses Istanbul's API for collecting coverage data and providing coverage reports.
 * [node-tap](https://github.com/tapjs/node-tap): a testing framework that bundles
   nyc for test coverage.
 * [nyc](https://github.com/istanbuljs/nyc): command line tool for instrumenting
-  code with Istanbul coverage (the successor to [istanbul](https://www.npmjs.com/package/istanbul)).
+  code with Istanbul coverage (the successor to the [istanbul](https://www.npmjs.com/package/istanbul) command line tool).

--- a/content/integrations/index.md
+++ b/content/integrations/index.md
@@ -5,6 +5,8 @@ title: Tools That Integrate With Istanbul API's
 The following tools integrate with Istanbul to provide JavaScript
 test coverage:
 
+* [nyc](https://github.com/istanbuljs/nyc): command line tool for instrumenting
+  code with Istanbul coverage (the successor to the [istanbul](https://www.npmjs.com/package/istanbul) command line tool).
 * [c8](https://github.com/bcoe/c8): Command line tool for executing code
   with V8's built in coverage enabled. Uses Istanbul reports for displaying
   coverage.
@@ -12,5 +14,3 @@ test coverage:
   works out of the box for any JavaScript project. Uses Istanbul's API for collecting coverage data and providing coverage reports.
 * [node-tap](https://github.com/tapjs/node-tap): a testing framework that bundles
   nyc for test coverage.
-* [nyc](https://github.com/istanbuljs/nyc): command line tool for instrumenting
-  code with Istanbul coverage (the successor to the [istanbul](https://www.npmjs.com/package/istanbul) command line tool).

--- a/content/integrations/index.md
+++ b/content/integrations/index.md
@@ -1,0 +1,17 @@
+---
+title: Tools That Integrate With Istanbul
+---
+
+The following tools integrate with Istanbul to provide JavaScript
+test coverage:
+
+* [c8](https://github.com/bcoe/c8): Command line tool for executing code
+  with V8's built in coverage enabled. Uses Istanbul reports for displaying
+  coverage.
+* [Jest](https://github.com/facebook/jest): JavaScript testing solution that
+  works out of the box for any React project. Uses Istanbul's API for providing
+  coverage reports.
+* [node-tap](https://github.com/tapjs/node-tap): a testing framework that bundles
+  nyc for test coverage.
+* [nyc](https://github.com/istanbuljs/nyc): command line tool for instrumenting
+  code with Istanbul coverage (the successor to [istanbul](https://www.npmjs.com/package/istanbul)).

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -55,6 +55,12 @@ export default class Header extends Component {
             >
               { "Contributing" }
             </Link>
+            <Link
+              className={ styles.link }
+              to="/integrations/"
+            >
+              { "Integrations" }
+            </Link>
             <a
               className={ styles.link }
               // eslint-disable-next-line max-len


### PR DESCRIPTION
Adding an integrations page, with the intention that `npm i istanbul` will start to display the following warning:

```
WARN: This module is no longer maintained, try "npm i nyc" instead. Visit https://istanbul.js.org/integrations for other alternatives."
```

<img width="1127" alt="screen shot 2019-01-30 at 5 51 44 pm" src="https://user-images.githubusercontent.com/194609/52025280-a27a0980-24b8-11e9-972c-548dd6cdaf7e.png">

CC: @SimenB