### PR TITLE
README: Add jsfuzz to integrations

### DIFF
--- a/content/integrations/index.md
+++ b/content/integrations/index.md
@@ -14,3 +14,4 @@ test coverage:
   works out of the box for any JavaScript project. Uses Istanbul's API for collecting coverage data and providing coverage reports.
 * [node-tap](https://www.node-tap.org/): a testing framework that bundles
   nyc for test coverage.
+* [jsfuzz](https://github.com/fuzzitdev/jsfuzz): Fuzz testing framework. Uses Istanbul's API for collecting coverage and guiding fuzzing process.


### PR DESCRIPTION
Hey Team,

We released [jsfuzz](https://github.com/fuzzitdev/jsfuzz) - fuzz testing framework for javascript and we are using IstanbulJs to guide the fuzzing process. would love to add it to the integrations.

Sidenote:  when choosing a coverage library for jsfuzz we tried both Istanbul and the new built-in NodeJS coverage and Istanbul outperformed (for our use-case) by x100 both by speed and precision. 

Cheers,
Yevgeny